### PR TITLE
Final mets creation now also works for empty levels (e.g. because the

### DIFF
--- a/pre-ingest/ingest/inc/get_mets.php
+++ b/pre-ingest/ingest/inc/get_mets.php
@@ -4,6 +4,7 @@
 // ** PURPOSE: BHLE INGESTION & PREPARATION  **
 // ** DATE:    05.11.2011                    **
 // ** AUTHOR:  ANDREAS MEHRRATH              **
+// ** AUTHOR:  WOLFGANG KOLLER               **
 // ********************************************
 // CREATE METS CONTROL FILES FOR INGEST
 // ********************************************
@@ -153,13 +154,14 @@ if (file_exists($olef_file))
         $ingestReady = false;
         $stepErrors = true;
     }
-    else
+    else {
         $stepFinished = true;
+        $ingestReady = true;
+    }
 
     echo "\n\n</pre>\n";
 }
-else
-    $stepErrors = true;
-
-
-?>
+else {
+    $stepFinished = true;
+    $ingestReady = false;
+}

--- a/pre-ingest/ingest/inc/serial_kernel_step.php
+++ b/pre-ingest/ingest/inc/serial_kernel_step.php
@@ -48,7 +48,7 @@ if ( $cPages == 0 ) {
 // Execute step for current directory
 // Check if directory contains a least one file, or if we are processing
 // the metadata (since for OAI-PMH providers the directory might be empty)
-if( !in_array($contentDir,$arrAnalyzedDirs) && (!is_dir_empty($contentDir,true) || $menu_nav == 'get_metadata') ) { //&&(!is_dir_empty($contentDir,true))) {
+if( !in_array($contentDir,$arrAnalyzedDirs) && (!is_dir_empty($contentDir,true) || $menu_nav == 'get_metadata' || $menu_nav == 'get_mets' ) ) { //&&(!is_dir_empty($contentDir,true))) {
     if (!is_dir($destDir)) @mkdir($destDir);        // WO NOETIG .AIP ANLEGEN
     
     $stepFinished   = false;                        // ZURUECKSETZEN DA FOLG. STEP ERFOLGREICH SEIN MUSS...


### PR DESCRIPTION
...ave the metadata fetched via OAI-PMH)

Fix for issue #449
